### PR TITLE
Telegram price-drop alerts

### DIFF
--- a/infra/postgres/init/02-schema.sql
+++ b/infra/postgres/init/02-schema.sql
@@ -93,7 +93,8 @@ CREATE TABLE IF NOT EXISTS property_history (
   old_price   NUMERIC(12,2),
   price       NUMERIC(12,2),
   status      TEXT,
-  event       TEXT NOT NULL              -- 'listed','price_drop','price_increase','status_change'
+  event       TEXT NOT NULL,             -- 'listed','price_drop','price_increase','status_change'
+  alerted_at  TIMESTAMPTZ                -- set once the drop was sent to subscribers
 );
 
 CREATE INDEX IF NOT EXISTS idx_property_history_property
@@ -150,6 +151,7 @@ CREATE TABLE IF NOT EXISTS contact_channels (
   approved_by TEXT,
   last_seen   TIMESTAMPTZ,
   query_count INTEGER DEFAULT 0,
+  alerts_enabled BOOLEAN DEFAULT false,   -- opted in to price-drop DMs (/alerts on)
   created_at  TIMESTAMPTZ DEFAULT NOW(),
   UNIQUE(channel, identifier)
 );

--- a/services/telegram-agent/src/alerts.ts
+++ b/services/telegram-agent/src/alerts.ts
@@ -1,0 +1,58 @@
+import { db } from './db';
+import type TelegramBot from 'node-telegram-bot-api';
+
+const fmt = (n: any) => `$${Number(n).toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+
+// Hourly sweep: digest un-alerted price drops to subscribers, then mark them.
+// Idempotent — safe no matter how often the ingest chain runs.
+export async function sendPriceDropAlerts(bot: TelegramBot) {
+  const drops = await db.query(
+    `SELECT h.time, h.old_price, h.price, p.address, p.zip_code, p.id AS property_id
+     FROM property_history h
+     JOIN properties p ON p.id = h.property_id
+     WHERE h.event = 'price_drop' AND h.alerted_at IS NULL
+       AND p.status IS DISTINCT FROM 'inactive'
+     ORDER BY h.old_price - h.price DESC`
+  );
+  if (!drops.rows.length) return;
+
+  const subs = await db.query(
+    `SELECT identifier FROM contact_channels
+     WHERE channel = 'telegram' AND alerts_enabled AND status = 'approved'`
+  );
+
+  if (subs.rows.length) {
+    const top = drops.rows.slice(0, 10);
+    const lines = top.map(d => {
+      const pct = d.old_price ? Math.round((1 - d.price / d.old_price) * 100) : 0;
+      return `📉 *${(d.address || '').split(',')[0]}* (${d.zip_code})\n     ${fmt(d.old_price)} → *${fmt(d.price)}* (−${pct}%)`;
+    }).join('\n\n');
+    const extra = drops.rows.length > top.length ? `\n\n…and ${drops.rows.length - top.length} more. Ask me "price drops this week".` : '';
+    const text = `🔔 *Price drops in Phoenix*\n\n${lines}${extra}`;
+
+    for (const s of subs.rows) {
+      await bot.sendMessage(Number(s.identifier), text, { parse_mode: 'Markdown' }).catch(() => {});
+    }
+    console.log(`Alerts: ${drops.rows.length} drops sent to ${subs.rows.length} subscribers`);
+  }
+
+  // Mark handled even with zero subscribers, so old drops don't pile up
+  await db.query(`UPDATE property_history SET alerted_at = NOW() WHERE event = 'price_drop' AND alerted_at IS NULL`);
+}
+
+export async function setAlerts(uid: string, enabled: boolean): Promise<boolean> {
+  const r = await db.query(
+    `UPDATE contact_channels SET alerts_enabled = $2
+     WHERE channel = 'telegram' AND identifier = $1 RETURNING 1`,
+    [uid, enabled]
+  );
+  if (r.rowCount) return true;
+  // Admins bypass ensureAccess and may have no row yet — create one approved
+  await db.query(
+    `INSERT INTO contact_channels (channel, identifier, status, alerts_enabled, approved_at, approved_by)
+     VALUES ('telegram', $1, 'approved', $2, NOW(), 'self')
+     ON CONFLICT (channel, identifier) DO UPDATE SET alerts_enabled = $2`,
+    [uid, enabled]
+  );
+  return true;
+}

--- a/services/telegram-agent/src/index.ts
+++ b/services/telegram-agent/src/index.ts
@@ -5,6 +5,7 @@ import { getStats, getZipSummary, searchProperties, getRecentJobs } from './quer
 import axios from 'axios';
 
 import { ensureAccess, isAdmin, setAccess, listUsers } from './access';
+import { sendPriceDropAlerts, setAlerts } from './alerts';
 
 const TOKEN = process.env.TELEGRAM_BOT_TOKEN!;
 const API_URL = process.env.AGENT_API_URL || 'http://127.0.0.1:3100';
@@ -44,6 +45,7 @@ bot.onText(/\/help/, async (msg) => {
     `/jobs — Recent scrape jobs\n` +
     `/scrape <zip> [zip2...] — Trigger a scrape\n\n` +
     `*Other*\n` +
+    `/alerts on|off — Price-drop alerts\n` +
     `/clear — Reset conversation\n\n` +
     `Or just ask naturally:\n` +
     `_"3-bed homes under $600k in 85254"_\n` +
@@ -133,6 +135,17 @@ bot.onText(/\/clear/, async (msg) => {
   pendingResults.delete(msg.chat.id);
   await axios.post(`${API_URL}/api/agent/clear`, { chatId: msg.chat.id, channel: 'telegram' }).catch(() => {});
   bot.sendMessage(msg.chat.id, '🧹 Conversation cleared.');
+});
+
+// ── /alerts on|off ────────────────────────────────────────
+bot.onText(/\/alerts(?:\s+(on|off))?/, async (msg, match) => {
+  if (!(await ensureAccess(bot, msg))) return;
+  const arg = match?.[1];
+  if (!arg) return bot.sendMessage(msg.chat.id, '🔔 Usage: /alerts on — daily price-drop alerts · /alerts off — stop them');
+  await setAlerts(String(msg.from?.id ?? msg.chat.id), arg === 'on');
+  bot.sendMessage(msg.chat.id, arg === 'on'
+    ? '🔔 Price-drop alerts ON — you\'ll get a digest when listings drop in price.'
+    : '🔕 Price-drop alerts OFF.');
 });
 
 // ── /users (admin) ────────────────────────────────────────
@@ -262,5 +275,8 @@ bot.on('message', async (msg) => {
     bot.sendMessage(msg.chat.id, '❌ Error. Try again.');
   }
 });
+
+// Hourly price-drop digest (idempotent via property_history.alerted_at)
+setInterval(() => sendPriceDropAlerts(bot).catch(err => console.error('Alerts error:', err.message)), 60 * 60 * 1000);
 
 console.log('PropScout Telegram agent started ✅');


### PR DESCRIPTION
Opt-in /alerts on|off; hourly digest of new price drops (top 10, % off), idempotent via property_history.alerted_at. Tested live end-to-end with a synthetic drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)